### PR TITLE
Fix: Correct chown command for docker directory

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -94,7 +94,7 @@ Great video resource by KeepItTechie: [https://www.youtube.com/watch?v=2gW4rWhur
 3. Set permissions of mount points created eariler.
 ```
 sudo chown -R brandon:brandon /data
-sudo chown -R brandon:brandon /data
+sudo chown -R brandon:brandon /docker
 ```
 4. Install Samba
 ```


### PR DESCRIPTION
Update the chown command in the storage README.md to use the correct path '/docker' instead of duplicating the '/data' path. This fixes the documentation in section 5, step 3.