### PR TITLE
Update README with wsdd-server installation note

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -195,6 +195,7 @@ In our new LXC we first need to run some general updates and user creation.
     sudo systemctl enable wsdd
     sudo systemctl start wsdd
     ```
+> For certain linux distributions (mainly Ubuntu 24+ and Debian), install the wsdd-server package instead as wsdd doesn't include the service in those anymore.
 
 11. Allow services on firewall if you run into any issues.
     ```bash


### PR DESCRIPTION
Added note about using wsdd-server package for Ubuntu 24+ and Debian. See this issue: https://github.com/christgau/wsdd/issues/212

Tested on Ubuntu 24.04-Standard on an LCX, and the wsdd package did not contain any services or manage to enable discoverability.