### PR TITLE
Add immich

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -36,4 +36,4 @@ docker exec nextcloud-aio-mastercontainer grep password /mnt/docker-aio-config/d
 ```
 
 ## Immich
-Work in progress.
+Self-hosted Google Photos alternative with mobile backup, facial recognition, and automatic organization. See the full setup guide in the [immich](https://github.com/TechHutTV/homelab/tree/main/cloud/immich) directory.

--- a/cloud/immich/.env
+++ b/cloud/immich/.env
@@ -10,14 +10,14 @@ DB_DATA_LOCATION=./postgres
 
 # Timezone - Change to your timezone
 # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
-TZ=America/New_York
+TZ=America/Los_Angeles
 
 # The Immich version to use. You can pin this to a specific version like "v2.1.0"
 IMMICH_VERSION=v2
 
-# Connection secret for postgres. You should change it to a random password
-# Please use only the characters `A-Za-z0-9`, without special characters or spaces
-DB_PASSWORD=postgres
+# Connection secret for postgres. CHANGE THIS to a random strong password.
+# Please use only the characters `A-Za-z0-9`, without special characters or spaces.
+DB_PASSWORD=CHANGE_ME_BEFORE_FIRST_RUN
 
 ###################################################################################
 # The values below this line do not need to be changed

--- a/cloud/immich/.env
+++ b/cloud/immich/.env
@@ -1,0 +1,26 @@
+# Immich Environment Variables
+# Documentation: https://docs.immich.app/install/environment-variables
+
+# The location where your uploaded files are stored
+UPLOAD_LOCATION=./library
+
+# The location where your database files are stored
+# Network shares are NOT supported for the database
+DB_DATA_LOCATION=./postgres
+
+# Timezone - Change to your timezone
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+TZ=America/New_York
+
+# The Immich version to use. You can pin this to a specific version like "v2.1.0"
+IMMICH_VERSION=v2
+
+# Connection secret for postgres. You should change it to a random password
+# Please use only the characters `A-Za-z0-9`, without special characters or spaces
+DB_PASSWORD=postgres
+
+###################################################################################
+# The values below this line do not need to be changed
+###################################################################################
+DB_USERNAME=postgres
+DB_DATABASE_NAME=immich

--- a/cloud/immich/README.md
+++ b/cloud/immich/README.md
@@ -1,26 +1,28 @@
 # Immich - Self-Hosted Photo and Video Backup
 
-Immich is a self-hosted alternative to Google Photos with a focus on privacy and control. It keeps your photos and videos on your own hardware with support for RAW files, facial recognition, and automatic organization. The mobile app for both [Android](https://play.google.com/store/apps/details?id=app.immich) and [iOS](https://apps.apple.com/app/immich/id1613945652) includes built-in photo backup support.
+Immich is a self-hosted alternative to Google Photos with a real focus on privacy. It keeps your photos and videos on your own hardware with full support for RAW files, facial recognition, and automatic organization. The mobile app for both [Android](https://play.google.com/store/apps/details?id=app.immich) and [iOS](https://apps.apple.com/app/immich/id1613945652) handles auto-backup out of the box, which is honestly the killer feature.
 
 > [!NOTE]
-> Most of the steps below are from their [official docs](https://docs.immich.app/install/docker-compose). Please check those out as well.
+> Most of the steps below are based on their [official docs](https://docs.immich.app/install/docker-compose). I'd give those a read too, especially as things change between versions.
 
 ## Prerequisites
-1. A server running Docker. Checkout our [docker guide](https://techhut.tv/7-docker-basics-for-beginners/) to get this going.
-2. Recommended 6GB of RAM and 4 core CPU. ([learn more](https://immich.app/docs/install/requirements))
-3. Enough storage for your media. Your needed amount will depend on your photography habits and current media collection.
+1. A server running Docker. Check out our [docker guide](https://techhut.tv/7-docker-basics-for-beginners/) if you're new to it.
+2. At least 6GB of RAM and a 4-core CPU is recommended ([learn more](https://immich.app/docs/install/requirements)).
+3. Enough storage for your media. This really depends on your collection. I'd plan for at least double what you currently have to leave room for growth.
 
 ## Setup
 
 ### Prepare Your Environment
-Create directories for Immich data. You may want to change the `library` location to a network drive or another location if your root file system has less storage than you may need. Checkout this example of [mounting drives](https://techhut.tv/auto-mount-drives-in-linux-fstab/) in Linux.
+Create a directory for Immich. If your root filesystem is small you'll probably want to point `library` at a network drive or external storage. Check out [this guide on auto-mounting drives](https://techhut.tv/auto-mount-drives-in-linux-fstab/) in Linux.
+
 ```bash
 mkdir -p ~/docker/immich
+cd ~/docker/immich
 ```
 
-Navigate to the directory and download the `compose.yaml` and `.env` files from this repo.
+Now go ahead and grab the `compose.yaml` and `.env` files from this repo.
+
 ```bash
-cd ~/docker/immich
 wget https://github.com/TechHutTV/homelab/raw/refs/heads/main/cloud/immich/compose.yaml && wget https://github.com/TechHutTV/homelab/raw/refs/heads/main/cloud/immich/.env
 ```
 
@@ -29,76 +31,117 @@ wget https://github.com/TechHutTV/homelab/raw/refs/heads/main/cloud/immich/compo
 nano .env
 ```
 
-**Mandatory Changes:**
-- `DB_PASSWORD` — Change to a random strong password. Use only `A-Za-z0-9` to avoid issues with Docker parsing.
+**You have to change these:**
+- `DB_PASSWORD` — Set this to a random strong password. Stick to `A-Za-z0-9` so Docker doesn't choke on special characters. The default is intentionally broken so the stack won't start until you change it.
 - `TZ` — Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
-- `UPLOAD_LOCATION` — Verify or change the path where your photos will be stored.
-- `DB_DATA_LOCATION` — Path for the PostgreSQL database. Network shares are **not** supported here.
+- `UPLOAD_LOCATION` — Where your photos and videos will live. Network shares are fine here.
+- `DB_DATA_LOCATION` — Where the Postgres database lives. Do **not** put this on a network share, Immich will not be happy.
 
 ### Deploy the Stack
 ```bash
 docker compose up -d
 ```
-Wait a few minutes for all containers to initialize. Check logs if any containers fail to start.
+
+Give it a few minutes to pull images and initialize. If something fails to start, check the logs:
 ```bash
 docker logs immich_server
 ```
 
 ### Access Immich
-1. Open `http://your-server-ip:2283` in your browser
-2. Create an admin account (first user becomes admin)
-3. Configure settings:
-   - **Storage Template** — Configure to make your library [human readable](https://immich.app/docs/install/post-install).
-   - **Machine Learning** — Enable facial recognition if using the ML container.
+1. Open `http://your-server-ip:2283` in your browser.
+2. Create your admin account. The first user to register becomes admin, so do this before sharing the URL with anyone.
+3. Configure the basics:
+   - **Storage Template** — Make your library [human readable](https://immich.app/docs/install/post-install) so backups outside Immich are useful.
+   - **Machine Learning** — Turn on facial recognition and smart search if you want it.
+
+And there we go, you should have Immich running.
 
 ## Mobile App Setup
-1. Install Immich from the [App Store](https://apps.apple.com/app/immich/id1613945652) or [Play Store](https://play.google.com/store/apps/details?id=app.immich)
+This is where Immich really shines. Auto-backup from your phone is the whole reason most people self-host this.
+
+1. Install Immich from the [App Store](https://apps.apple.com/app/immich/id1613945652) or [Play Store](https://play.google.com/store/apps/details?id=app.immich).
 2. Connect to your server:
    - Server URL: `http://your-server-ip:2283`
-   - Use your admin credentials
-3. Enable auto-backup in the app settings
+   - Log in with the admin account you just created (or a regular user account if you set one up).
+3. Head into settings and turn on auto-backup. Pick your photo and video albums, set the backup behavior (foreground, background, on Wi-Fi only, and whatnot), and you're good to go.
 
 ## Remote Access
-- **[NetBird](https://netbird.io/) (Recommended)** — A zero-trust networking solution using WireGuard. Access Immich securely from anywhere without exposing ports. Follow our [NetBird setup guide](https://techhut.tv/self-host-netbird-pocketid) to get started.
-- **Reverse Proxy** — Setup NGINX Proxy Manager for domain-based access ([video guide](https://www.youtube.com/watch?v=79e6KBYcVmQ)). Forward `photos.yourdomain.com` to `http://immich-server:2283`.
+Hosting Immich at home is great, but you'll probably want to reach it from outside your network for backups while traveling.
+
+- **[NetBird](https://netbird.io/) (Recommended)** — A zero-trust mesh network built on WireGuard. No port forwarding, no exposing services to the open internet. Follow our [NetBird setup guide](https://techhut.tv/self-host-netbird-pocketid) to get going.
+- **Reverse Proxy** — If you want a clean URL like `photos.yourdomain.com`, set up NGINX Proxy Manager ([video guide](https://www.youtube.com/watch?v=79e6KBYcVmQ)). Forward your hostname to `http://immich-server:2283` and you're set.
 
 ## Optional Configuration
 
 ### Hardware Transcoding
-Uncomment the `devices` section in the `immich-server` service in `compose.yaml` to enable Intel QuickSync for video transcoding. [Learn more](https://immich.app/docs/features/hardware-transcoding/#single-compose-file).
+For Intel QuickSync, uncomment the `devices` section in the `immich-server` service in `compose.yaml`. This speeds up video transcoding significantly. [Learn more](https://immich.app/docs/features/hardware-transcoding/#single-compose-file).
+
+```yaml
+devices:
+  - /dev/dri:/dev/dri
+```
 
 ### Hardware-Accelerated Machine Learning
-Uncomment and adjust the `immich-machine-learning` section in `compose.yaml`. [Learn more](https://immich.app/docs/features/ml-hardware-acceleration).
+The `compose.yaml` has commented blocks for Intel OpenVINO and Google Coral. Pick the one matching your accelerator, uncomment, and recompose. For NVIDIA, AMD, ARM NN, or RKNN check the [full hardware ML docs](https://immich.app/docs/features/ml-hardware-acceleration).
+
+If you don't have any hardware acceleration, that's fine. ML runs on CPU by default and works well enough for most homelab libraries.
 
 ### External Libraries
-You can add existing photo directories as [external libraries](https://immich.app/docs/features/libraries/).
+External libraries let Immich index existing photo directories without copying them into its managed storage. Super useful if you already have a sorted library on disk and don't want to import everything.
+
+To use them, mount the directory into the `immich-server` container so it can read it:
+```yaml
+immich-server:
+  volumes:
+    - ${UPLOAD_LOCATION}:/data
+    - /mnt/photos:/mnt/photos:ro  # read-only is safer for existing libraries
+    - /etc/localtime:/etc/localtime:ro
+```
+
+Then in the Immich web UI go to _Administration > Libraries_, create a new External Library for the admin user, and add `/mnt/photos` as the import path. Do note that the path is the path **inside the container**, not your host. [Learn more](https://immich.app/docs/features/libraries/).
 
 ### Disable Machine Learning
-If you don't need facial recognition or smart search, remove the entire `immich-machine-learning` service from `compose.yaml`.
+If you don't want facial recognition or smart search, you can drop the whole `immich-machine-learning` service from `compose.yaml`. This saves a few GB of RAM, which is nice on a smaller server.
+
+### Bulk Uploading with the CLI
+If you've got a giant existing library you want to import (rather than mount as external), the [Immich CLI](https://immich.app/docs/features/command-line-interface) is the way to go. It's way faster than dragging files into the web UI and handles huge batches without timing out.
+
+Install it on your desktop or any machine that can reach the server:
+```bash
+npm install -g @immich/cli
+```
+
+Then log in and upload:
+```bash
+immich login http://your-server-ip:2283 your-api-key
+immich upload --recursive /path/to/your/photos
+```
+
+You can grab an API key from _Account Settings > API Keys_ in the web UI.
 
 ## Storage Templates
+Storage templates automatically sort photos into folders based on metadata like date or camera model. This is what makes your library actually browsable outside Immich, which matters a lot if you're ever doing manual backups or migrating.
 
-Storage templates let you automatically sort photos into folders based on metadata like date, camera model, or custom tags. This makes your library human-readable and easier to back up.
-
-Example template:
+A solid default:
 ```
 {{y}}/{{MMMM}}-{{DD}}/{{filename}}
 ```
 Generates: `2024/July-15/IMG_1234.jpg`
 
-Go to **Settings** > **Storage Template** in the Immich web UI to configure this. You can apply templates to new uploads and re-run them on existing libraries.
+Go to _Settings > Storage Template_ in the web UI to set this up. You can also re-run it on existing libraries, which is great if you change your mind on the structure later.
 
 ## Backup Strategy
-- Regularly back up your database directory (`DB_DATA_LOCATION`)
-- Use an external backup tool or service to keep a copy of your photo library offsite
+- Back up your `DB_DATA_LOCATION` directory regularly. Without the database, your photos lose all metadata, faces, and albums.
+- Keep a copy of your `UPLOAD_LOCATION` somewhere offsite. I use [restic](https://restic.net/) to a Backblaze B2 bucket, but rsync to another machine works fine for smaller libraries.
+- The whole thing is just files on disk and a Postgres dump, so you don't need any Immich-specific backup tool.
 
 ## Troubleshooting
 
-**Port Conflicts** — Ensure port 2283 is available on your host.
+**Port Conflicts** — Make sure port 2283 is free, or remap with `IMMICH_PORT` in your `.env` (e.g. `IMMICH_PORT=8283`).
 
-**Permission Errors** — Verify volume permissions with `ls -l` on your upload and database directories.
+**Permission Errors** — Check ownership on your `UPLOAD_LOCATION` and `DB_DATA_LOCATION` directories with `ls -l`. The Immich containers run as their own user inside.
 
-**ML Container Failing** — Try disabling GPU support or allocate more RAM.
+**ML Container Failing** — Usually a RAM issue. Either give the host more memory or temporarily disable ML by removing the `immich-machine-learning` service.
 
 **Reset Admin Password:**
 ```bash
@@ -106,6 +149,20 @@ docker exec immich_server npm run reset-admin-password
 ```
 
 ## Maintenance
-- Re-deploy with updated image tags to update. Follow [Immich releases](https://github.com/immich-app/immich/releases).
-- Monitor your `UPLOAD_LOCATION` directory for storage growth.
-- Set retention policies in the Immich web UI as needed.
+
+### Updating
+To pull the latest images and recreate the containers:
+```bash
+docker compose pull && docker compose up -d
+```
+
+The `.env` ships with `IMMICH_VERSION=v2`, which pins to the v2 major version. You'll auto-get minor and patch updates but stay on v2 forever until you bump it manually. This is intentional. Immich does ship breaking schema changes in major releases, so do go check the [release notes](https://github.com/immich-app/immich/releases) before jumping to v3 (or whatever's next).
+
+If you want to pin to an exact version for stability, change `IMMICH_VERSION` to something like `v2.1.0`.
+
+### Housekeeping
+- Watch your `UPLOAD_LOCATION` for storage growth. The mobile app will quietly fill it up.
+- Set retention policies in _Administration > Settings > Trash_ if you want auto-cleanup.
+- Run _Administration > Jobs > External Library Scan_ periodically if you're using external libraries that change.
+
+With all that, you should have a pretty solid Immich setup. I do hope this helps, have a great one.

--- a/cloud/immich/README.md
+++ b/cloud/immich/README.md
@@ -1,0 +1,111 @@
+# Immich - Self-Hosted Photo and Video Backup
+
+Immich is a self-hosted alternative to Google Photos with a focus on privacy and control. It keeps your photos and videos on your own hardware with support for RAW files, facial recognition, and automatic organization. The mobile app for both [Android](https://play.google.com/store/apps/details?id=app.immich) and [iOS](https://apps.apple.com/app/immich/id1613945652) includes built-in photo backup support.
+
+> [!NOTE]
+> Most of the steps below are from their [official docs](https://docs.immich.app/install/docker-compose). Please check those out as well.
+
+## Prerequisites
+1. A server running Docker. Checkout our [docker guide](https://techhut.tv/7-docker-basics-for-beginners/) to get this going.
+2. Recommended 6GB of RAM and 4 core CPU. ([learn more](https://immich.app/docs/install/requirements))
+3. Enough storage for your media. Your needed amount will depend on your photography habits and current media collection.
+
+## Setup
+
+### Prepare Your Environment
+Create directories for Immich data. You may want to change the `library` location to a network drive or another location if your root file system has less storage than you may need. Checkout this example of [mounting drives](https://techhut.tv/auto-mount-drives-in-linux-fstab/) in Linux.
+```bash
+mkdir -p ~/docker/immich
+```
+
+Navigate to the directory and download the `compose.yaml` and `.env` files from this repo.
+```bash
+cd ~/docker/immich
+wget https://github.com/TechHutTV/homelab/raw/refs/heads/main/cloud/immich/compose.yaml && wget https://github.com/TechHutTV/homelab/raw/refs/heads/main/cloud/immich/.env
+```
+
+### Configure the .env File
+```bash
+nano .env
+```
+
+**Mandatory Changes:**
+- `DB_PASSWORD` — Change to a random strong password. Use only `A-Za-z0-9` to avoid issues with Docker parsing.
+- `TZ` — Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
+- `UPLOAD_LOCATION` — Verify or change the path where your photos will be stored.
+- `DB_DATA_LOCATION` — Path for the PostgreSQL database. Network shares are **not** supported here.
+
+### Deploy the Stack
+```bash
+docker compose up -d
+```
+Wait a few minutes for all containers to initialize. Check logs if any containers fail to start.
+```bash
+docker logs immich_server
+```
+
+### Access Immich
+1. Open `http://your-server-ip:2283` in your browser
+2. Create an admin account (first user becomes admin)
+3. Configure settings:
+   - **Storage Template** — Configure to make your library [human readable](https://immich.app/docs/install/post-install).
+   - **Machine Learning** — Enable facial recognition if using the ML container.
+
+## Mobile App Setup
+1. Install Immich from the [App Store](https://apps.apple.com/app/immich/id1613945652) or [Play Store](https://play.google.com/store/apps/details?id=app.immich)
+2. Connect to your server:
+   - Server URL: `http://your-server-ip:2283`
+   - Use your admin credentials
+3. Enable auto-backup in the app settings
+
+## Remote Access
+- **[NetBird](https://netbird.io/) (Recommended)** — A zero-trust networking solution using WireGuard. Access Immich securely from anywhere without exposing ports. Follow our [NetBird setup guide](https://techhut.tv/self-host-netbird-pocketid) to get started.
+- **Reverse Proxy** — Setup NGINX Proxy Manager for domain-based access ([video guide](https://www.youtube.com/watch?v=79e6KBYcVmQ)). Forward `photos.yourdomain.com` to `http://immich-server:2283`.
+
+## Optional Configuration
+
+### Hardware Transcoding
+Uncomment the `devices` section in the `immich-server` service in `compose.yaml` to enable Intel QuickSync for video transcoding. [Learn more](https://immich.app/docs/features/hardware-transcoding/#single-compose-file).
+
+### Hardware-Accelerated Machine Learning
+Uncomment and adjust the `immich-machine-learning` section in `compose.yaml`. [Learn more](https://immich.app/docs/features/ml-hardware-acceleration).
+
+### External Libraries
+You can add existing photo directories as [external libraries](https://immich.app/docs/features/libraries/).
+
+### Disable Machine Learning
+If you don't need facial recognition or smart search, remove the entire `immich-machine-learning` service from `compose.yaml`.
+
+## Storage Templates
+
+Storage templates let you automatically sort photos into folders based on metadata like date, camera model, or custom tags. This makes your library human-readable and easier to back up.
+
+Example template:
+```
+{{y}}/{{MMMM}}-{{DD}}/{{filename}}
+```
+Generates: `2024/July-15/IMG_1234.jpg`
+
+Go to **Settings** > **Storage Template** in the Immich web UI to configure this. You can apply templates to new uploads and re-run them on existing libraries.
+
+## Backup Strategy
+- Regularly back up your database directory (`DB_DATA_LOCATION`)
+- Use an external backup tool or service to keep a copy of your photo library offsite
+
+## Troubleshooting
+
+**Port Conflicts** — Ensure port 2283 is available on your host.
+
+**Permission Errors** — Verify volume permissions with `ls -l` on your upload and database directories.
+
+**ML Container Failing** — Try disabling GPU support or allocate more RAM.
+
+**Reset Admin Password:**
+```bash
+docker exec immich_server npm run reset-admin-password
+```
+
+## Maintenance
+- Re-deploy with updated image tags to update. Follow [Immich releases](https://github.com/immich-app/immich/releases).
+- Monitor your `UPLOAD_LOCATION` directory for storage growth.
+- Set retention policies in the Immich web UI as needed.

--- a/cloud/immich/compose.yaml
+++ b/cloud/immich/compose.yaml
@@ -1,0 +1,74 @@
+#############################################################################
+# Immich - Self-Hosted Photo and Video Backup
+# https://immich.app
+#
+# Make a '.env' file in the same directory as this file.
+# Adjust any settings as needed, especially DB_PASSWORD and volume paths.
+# https://github.com/TechHutTV/homelab/tree/main/cloud/immich#setup
+#############################################################################
+
+services:
+  immich-server:
+    container_name: immich_server
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+    volumes:
+      - ${UPLOAD_LOCATION}:/data
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - .env
+    ports:
+      - 2283:2283
+    depends_on:
+      - redis
+      - database
+    restart: always
+    healthcheck:
+      disable: false
+    # Hardware Transcoding (Intel) - uncomment if needed
+    # devices:
+    #   - /dev/dri:/dev/dri
+
+  immich-machine-learning:
+    container_name: immich_machine_learning
+    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
+    volumes:
+      - model-cache:/cache
+    env_file:
+      - .env
+    restart: always
+    healthcheck:
+      disable: false
+    # Hardware-Accelerated ML (Intel OpenVINO) - uncomment and change image tag if needed
+    # image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}-openvino
+    # device_cgroup_rules:
+    #   - 'c 189:* rmw'
+    # devices:
+    #   - /dev/dri:/dev/dri
+    # volumes:
+    #   - /dev/bus/usb:/dev/bus/usb
+    #   - model-cache:/cache
+
+  redis:
+    container_name: immich_redis
+    image: docker.io/valkey/valkey:9-alpine
+    healthcheck:
+      test: redis-cli ping || exit 1
+    restart: always
+
+  database:
+    container_name: immich_postgres
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_INITDB_ARGS: '--data-checksums'
+    volumes:
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+    shm_size: 128mb
+    restart: always
+    healthcheck:
+      disable: false
+
+volumes:
+  model-cache:

--- a/cloud/immich/compose.yaml
+++ b/cloud/immich/compose.yaml
@@ -17,14 +17,14 @@ services:
     env_file:
       - .env
     ports:
-      - 2283:2283
+      - ${IMMICH_PORT:-2283}:2283
     depends_on:
       - redis
       - database
-    restart: always
+    restart: unless-stopped
     healthcheck:
       disable: false
-    # Hardware Transcoding (Intel) - uncomment if needed
+    # Hardware Transcoding (Intel QuickSync) - uncomment if needed
     # devices:
     #   - /dev/dri:/dev/dri
 
@@ -35,15 +35,21 @@ services:
       - model-cache:/cache
     env_file:
       - .env
-    restart: always
+    restart: unless-stopped
     healthcheck:
       disable: false
-    # Hardware-Accelerated ML (Intel OpenVINO) - uncomment and change image tag if needed
+    # Hardware-Accelerated ML — uncomment the block matching your accelerator.
+    # See https://immich.app/docs/features/ml-hardware-acceleration for the full list (NVIDIA CUDA, AMD ROCm, ARM NN, RKNN).
+    #
+    # Intel OpenVINO (iGPU / Arc):
     # image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}-openvino
-    # device_cgroup_rules:
-    #   - 'c 189:* rmw'
     # devices:
     #   - /dev/dri:/dev/dri
+    #
+    # Google Coral USB Accelerator:
+    # image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}-armnn
+    # device_cgroup_rules:
+    #   - 'c 189:* rmw'
     # volumes:
     #   - /dev/bus/usb:/dev/bus/usb
     #   - model-cache:/cache
@@ -53,7 +59,7 @@ services:
     image: docker.io/valkey/valkey:9-alpine
     healthcheck:
       test: redis-cli ping || exit 1
-    restart: always
+    restart: unless-stopped
 
   database:
     container_name: immich_postgres
@@ -66,7 +72,7 @@ services:
     volumes:
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
     shm_size: 128mb
-    restart: always
+    restart: unless-stopped
     healthcheck:
       disable: false
 


### PR DESCRIPTION
## Summary
Adds Immich (self-hosted Google Photos alternative) as a new guide under `cloud/immich/`, replaces the `cloud/README.md` placeholder with a real one-line summary, and pulls in the upstream Immich compose pattern with sensible homelab defaults.

## Changes

### `cloud/immich/compose.yaml`
- Full Immich stack: `immich-server`, `immich-machine-learning`, `redis` (Valkey 9), and `database` (Immich's pinned Postgres image with vectorchord/pgvectors).
- `shm_size: 128mb` on the DB, `POSTGRES_INITDB_ARGS: '--data-checksums'` for hardening.
- Templated port: `${IMMICH_PORT:-2283}:2283` so users can remap without editing compose.
- `restart: unless-stopped` across all services to match the rest of the repo.
- Commented hardware sections split into properly-labeled **Intel QuickSync** (transcoding), **Intel OpenVINO** (ML iGPU), and **Google Coral USB Accelerator** (ML), with a pointer to upstream docs for NVIDIA / AMD / ARM NN / RKNN.

### `cloud/immich/.env`
- `UPLOAD_LOCATION`, `DB_DATA_LOCATION`, `TZ`, `IMMICH_VERSION` (pinned to `v2`), DB credentials.
- `DB_PASSWORD=CHANGE_ME_BEFORE_FIRST_RUN` — intentionally broken default so the stack won't start until the user sets a real password.

### `cloud/immich/README.md`
- Full setup guide: prerequisites, .env config, deploy, mobile app, remote access via NetBird / NPM, hardware acceleration, External Libraries with the container-path gotcha, bulk uploading via `@immich/cli`, storage templates, backup strategy, troubleshooting, and update/maintenance.
- Update command and `IMMICH_VERSION=v2` major-pinning explanation included.

### `cloud/README.md`
- Replaces the "Work in progress." line under the Immich section with a real summary linking to the new folder.
