### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Currently running two camera systems - originally fully Reolink, but added UniFi
 
 ## Stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=techhuttv/homelab&type=date&legend=top-left)](https://www.star-history.com/#techhuttv/homelab&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=techhuttv/homelab&type=date&legend=top-left)](https://star-history.dera.page/#techhuttv/homelab&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README stopped working due to an issue with the upstream service and is no longer loading. This switches the chart to a working source so the graph renders properly again.